### PR TITLE
Wrap News widget in the expected container element

### DIFF
--- a/includes/dashboard-widget.php
+++ b/includes/dashboard-widget.php
@@ -15,7 +15,11 @@ function nearbywp_render_dashboard_widget() {
 		<?php esc_html_e( 'This widget requires JavaScript.' ); ?>
 	</div>
 
-	<?php wp_dashboard_primary(); ?>
+	<div id="dashboard_primary">
+		<div class="inside">
+			<?php wp_dashboard_primary(); ?>
+		</div>
+	</div>
 
 	<p class="nearbywp-footer">
 		<a href="<?php esc_html_e( 'https://www.meetup.com/pro/wordpress/' ); ?>"><?php esc_html_e( 'Meetups' ); ?> <span class="dashicons dashicons-external"></span></a> | <a href="<?php esc_html_e( 'https://central.wordcamp.org/schedule/' ); ?>"><?php esc_html_e( 'WordCamps' ); ?> <span class="dashicons dashicons-external"></span></a> | <a href="<?php esc_html_e( 'https://wordpress.org/news/' ); ?>"><?php esc_html_e( 'News' ); ?> <span class="dashicons dashicons-external"></span></a>


### PR DESCRIPTION
Without this element, Core's JS doesn't know where to store the news payload, and the News section of the widget just displays `Loading...`.