### PR TITLE
Change <em> to closing </em> tag

### DIFF
--- a/includes/script-loader.php
+++ b/includes/script-loader.php
@@ -53,7 +53,7 @@ function nearbywp_get_inline_script_data() {
 			 * to the user, so it's left as an implication.
 			 */
 			/* translators: %s is the name of the city we couldn't locate. Replace the examples with cities in your locale, but test that they match the expected location before including them. Use endonyms (native locale names) whenever possible. */
-			'could_not_locate_city' => __( 'We couldn\'t locate <strong><em>%s</em></strong>. Please try another nearby city. For example: <em>Kansas City; Springfield; Portland<em>.', 'nearby-wp-events' ),
+			'could_not_locate_city' => __( 'We couldn\'t locate <strong><em>%s</em></strong>. Please try another nearby city. For example: <em>Kansas City; Springfield; Portland</em>.', 'nearby-wp-events' ),
 
 			// This one is only used with wp.a11y.speak(), so it can/should be more brief.
 			/* translators: %s is the name of a city. */


### PR DESCRIPTION
In the string `We couldn't locate <strong><em>%s</em></strong>. Please try another nearby city. For example: <em>Kansas City; Springfield; Portland<em>.`, the second `<em>` tag should be a closing `</em>`.

I've posted in #meta-i18n https://wordpress.slack.com/archives/C0341VCNL/p1496865412809326
And incorrectly opened a Ticket in https://core.trac.wordpress.org/ticket/40941